### PR TITLE
Run systems that recreate resources for light plugin only on event, and only once

### DIFF
--- a/bevy_magic_light_2d/src/lib.rs
+++ b/bevy_magic_light_2d/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
 
 pub mod gi;
 pub mod prelude;


### PR DESCRIPTION
Sometimes the `WindowResize` event was emitted multiple times during one frame.