### PR TITLE
Ignoring assets with .import and .log extensions 

### DIFF
--- a/common/assets/src/ignore_loader.rs
+++ b/common/assets/src/ignore_loader.rs
@@ -1,0 +1,33 @@
+//! Bevy attempts to load any file in the asset directory when loading folders.
+//! However, there are file patterns we want to ignore.
+//! Add extensions to this loader to skip file loading.
+//!
+//! <https://github.com/bevyengine/bevy/pull/11214#issuecomment-1996004344>
+
+use std::convert::Infallible;
+
+use bevy::asset::{io::Reader, AssetLoader, LoadContext};
+
+/// Files loaded by this loader are ignored.
+/// The bytes are not polled from the reader.
+#[derive(Debug, Default)]
+pub struct Loader;
+
+impl AssetLoader for Loader {
+    type Asset = ();
+    type Settings = ();
+    type Error = Infallible;
+
+    fn load<'a>(
+        &'a self,
+        _reader: &'a mut Reader,
+        _settings: &'a Self::Settings,
+        _load_context: &'a mut LoadContext,
+    ) -> bevy::utils::BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["import", "log"]
+    }
+}

--- a/common/assets/src/lib.rs
+++ b/common/assets/src/lib.rs
@@ -1,62 +1,11 @@
 //! Exports paths to the assets used by the game.
-//! Also exports a [`RonLoader`] for loading assets from .ron files.
+//! Also exports a [`ron_loader::Loader`] for loading assets from .ron files.
 //! We store e.g. level layouts this way.
 
+pub mod ignore_loader;
 mod paths;
+pub mod ron_loader;
 pub mod store;
 
-use std::marker::PhantomData;
-
-use bevy::asset::{io::Reader, Asset, AssetLoader, AsyncReadExt, LoadContext};
 pub use paths::*;
-use serde::de::DeserializeOwned;
 pub use store::AssetStore;
-use thiserror::Error;
-
-/// Loads assets from .ron files.
-/// The specific type of asset is determined by the type parameter `T`.
-#[derive(Debug)]
-pub struct RonLoader<T>(PhantomData<T>);
-
-/// Errors that can occur when loading assets from .ron files.
-#[non_exhaustive]
-#[derive(Debug, Error)]
-pub enum LoaderError {
-    /// The file could not be loaded, most likely not found.
-    #[error("Could load ron file: {0}")]
-    Io(#[from] std::io::Error),
-    /// The string must be parsable into the `T` type.
-    #[error("Could not parse ron file: {0}")]
-    Ron(#[from] ron::de::SpannedError),
-}
-
-impl<T: Asset + DeserializeOwned> AssetLoader for RonLoader<T> {
-    type Asset = T;
-    type Settings = ();
-    type Error = LoaderError;
-
-    fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader,
-        _settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext,
-    ) -> bevy::utils::BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
-        Box::pin(async move {
-            let mut bytes = Vec::new();
-            reader.read_to_end(&mut bytes).await?;
-
-            bevy::log::trace!("Loading RON for {}", T::type_path(),);
-            Ok(ron::de::from_bytes(&bytes)?)
-        })
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["ron"]
-    }
-}
-
-impl<T> Default for RonLoader<T> {
-    fn default() -> Self {
-        Self(PhantomData)
-    }
-}

--- a/common/assets/src/ron_loader.rs
+++ b/common/assets/src/ron_loader.rs
@@ -1,0 +1,53 @@
+use std::marker::PhantomData;
+
+use bevy::asset::{io::Reader, Asset, AssetLoader, AsyncReadExt, LoadContext};
+use serde::de::DeserializeOwned;
+use thiserror::Error;
+
+/// Loads assets from .ron files.
+/// The specific type of asset is determined by the type parameter `T`.
+#[derive(Debug)]
+pub struct Loader<T>(PhantomData<T>);
+
+/// Errors that can occur when loading assets from .ron files.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum LoaderError {
+    /// The file could not be loaded, most likely not found.
+    #[error("Could load ron file: {0}")]
+    Io(#[from] std::io::Error),
+    /// The string must be parsable into the `T` type.
+    #[error("Could not parse ron file: {0}")]
+    Ron(#[from] ron::de::SpannedError),
+}
+
+impl<T: Asset + DeserializeOwned> AssetLoader for Loader<T> {
+    type Asset = T;
+    type Settings = ();
+    type Error = LoaderError;
+
+    fn load<'a>(
+        &'a self,
+        reader: &'a mut Reader,
+        _settings: &'a Self::Settings,
+        _load_context: &'a mut LoadContext,
+    ) -> bevy::utils::BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+        Box::pin(async move {
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await?;
+
+            bevy::log::trace!("Loading RON for {}", T::type_path(),);
+            Ok(ron::de::from_bytes(&bytes)?)
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["ron"]
+    }
+}
+
+impl<T> Default for Loader<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/common/top_down/src/lib.rs
+++ b/common/top_down/src/lib.rs
@@ -69,7 +69,7 @@ pub fn default_setup_for_scene<T: TopDownScene, S: States + Copy>(
     debug!("Adding map layout for {}", T::type_path());
 
     app.add_event::<ActorMovementEvent<T::LocalTileKind>>()
-        .init_asset_loader::<common_assets::RonLoader<TileMap<T>>>()
+        .init_asset_loader::<common_assets::ron_loader::Loader<TileMap<T>>>()
         .init_asset::<TileMap<T>>()
         .register_type::<TileKind<T::LocalTileKind>>()
         .register_type::<TileMap<T>>()

--- a/main_game_lib/src/lib.rs
+++ b/main_game_lib/src/lib.rs
@@ -72,7 +72,8 @@ pub fn windowed_app() -> App {
         .insert_resource(ClearColor(PRIMARY_COLOR))
         .insert_resource(GlobalGameStateTransitionStack::default())
         .init_asset::<common_rscn::TscnTree>()
-        .init_asset_loader::<common_rscn::TscnLoader>();
+        .init_asset_loader::<common_rscn::TscnLoader>()
+        .init_asset_loader::<common_assets::ignore_loader::Loader>();
 
     #[cfg(feature = "devtools")]
     {


### PR DESCRIPTION
Introducing an asset loader matching these extensions that does not poll the async reader, hence not reading the file bytes. It instead simply inserts a unit type as the loaded asset.

---

Closes #87